### PR TITLE
Close file descriptors after reading. Gives ResourceWarning in python

### DIFF
--- a/src/jwkest/jwk.py
+++ b/src/jwkest/jwk.py
@@ -90,7 +90,11 @@ DIGEST_HASH = {
 
 
 def import_rsa_key_from_file(filename, passphrase=None):
-    return RSA.importKey(open(filename, 'r').read(), passphrase=passphrase)
+    content = None
+    with open(filename, 'r') as f:
+        content = f.read()
+
+    return RSA.importKey(content, passphrase=passphrase)
 
 
 def import_rsa_key(key, passphrase=None):
@@ -117,7 +121,10 @@ def der2rsa(der):
 
 def pem_cert2rsa(pem_file):
     # Convert from PEM to DER
-    pem = open(pem_file).read()
+    pem = None
+    with open(pem_file) as f:
+        pem = f.read()
+
     _rsa = RSA.importKey(pem)
     lines = pem.replace(" ", '').split()
     return der2rsa(a2b_base64(''.join(lines[1:-1])))
@@ -161,7 +168,9 @@ def load_x509_cert(url, spec2key):
 
 def rsa_load(filename):
     """Read a PEM-encoded RSA key pair from a file."""
-    pem = open(filename, 'r').read()
+    pem = None
+    with open(filename, 'r') as f:
+        pem = f.read()
     return import_rsa_key(pem)
 
 


### PR DESCRIPTION
Turned on warnings in my project by:

```
import warnings
warnings.simplefilter('always', ResourceWarning)
```
Got below warning.

> /usr/lib/python3.5/dist-packages/jwkest/jwk.py:164: ResourceWarning: unclosed file <_io.TextIOWrapper name='/localdisk/amuralid/container/ub/scale/rift/.build/ub16_debug/install/usr/rift/usr/share/var/etc/ssl/private/current.key' mode='r' encoding='UTF-8'>
>   pem = open(filename, 'r').read()

This patch explicitly closes the file object by using context manager.