### PR TITLE
Fixed coordinate lengths for elliptic key curves.

### DIFF
--- a/src/jwkest/__init__.py
+++ b/src/jwkest/__init__.py
@@ -102,8 +102,12 @@ def long2intarr(long_int):
     return _bytes
 
 
-def long_to_base64(n):
+def long_to_base64(n, mlen=0):
     bys = long2intarr(n)
+    if mlen:
+        _len = mlen - len(bys)
+        if _len:
+            bys = [0] * _len + bys
     data = struct.pack('%sB' % len(bys), *bys)
     if not len(data):
         data = '\x00'

--- a/src/jwkest/jwk.py
+++ b/src/jwkest/jwk.py
@@ -628,14 +628,15 @@ class ECKey(Key):
             raise SerializationNotPossible()
 
         res = self.common()
+        blen = self.curve.bytes
         res.update({
             "crv": self.curve.name(),
-            "x": long_to_base64(self.x),
-            "y": long_to_base64(self.y)
+            "x": long_to_base64(self.x, blen),
+            "y": long_to_base64(self.y, blen)
         })
 
         if private and self.d:
-            res["d"] = long_to_base64(self.d)
+            res["d"] = long_to_base64(self.d, blen)
 
         return res
 

--- a/tests/test_4_jwe.py
+++ b/tests/test_4_jwe.py
@@ -25,7 +25,7 @@ __author__ = 'rohe0002'
 
 
 def intarr2bytes(arr):
-    return array.array('B', arr).tostring()
+    return array.array('B', arr).tobytes()
 
 
 def bytes2intarr(bts):

--- a/tests/test_4_jwe.py
+++ b/tests/test_4_jwe.py
@@ -25,7 +25,7 @@ __author__ = 'rohe0002'
 
 
 def intarr2bytes(arr):
-    return array.array('B', arr).tobytes()
+    return array.array('B', arr).tostring()
 
 
 def bytes2intarr(bts):


### PR DESCRIPTION
According to https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40#section-6.2 the coordinates for an elliptic curve key must be of a specific length. 