### PR TITLE
Added long_description and url to GitHub Repo for use on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,9 +30,11 @@ setup(
     name="pyjwkest",
     version=version,
     description="Python implementation of JWT, JWE, JWS and JWK",
+    long_description=io.open('README.rst', encoding='utf-8').read() if exists("README.rst") else "",
     author="Roland Hedberg",
     author_email="roland@catalogix.se",
     license="Apache 2.0",
+    url='https://github.com/IdentityPython/pyjwkest',
     packages=["jwkest"],
     package_dir={"": "src"},
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,8 @@
 
 import glob
 import re
+import io
+from os.path import exists
 
 from setuptools import setup
 


### PR DESCRIPTION
This project's display on [PyPI](https://pypi.org/project/pyjwkest/) is lacking the long description and a url for the GitHub Repo. I added long_description, which reads from the project's README.rst, and the repo url.