### PR TITLE
Added missing length bytes for AlgorithmID to otherInfo.

### DIFF
--- a/src/jwkest/extra.py
+++ b/src/jwkest/extra.py
@@ -176,8 +176,16 @@ def ecdh_derive_key(curve, key, epk, apu, apv, alg, dk_len):
     Z = curve.dh_z(key, epk)
     # Derive the key
     # AlgorithmID || PartyUInfo || PartyVInfo || SuppPubInfo
-    otherInfo = bytes(alg) + \
-        pack("!I", len(apu)) + apu + \
-        pack("!I", len(apv)) + apv + \
-        pack("!I", dk_len)
+    # otherInfo = bytes(alg) + \
+    #     pack("!I", len(apu)) + apu + \
+    #     pack("!I", len(apv)) + apv + \
+    #     pack("!I", dk_len)
+    otherInfo = bytearray()
+    otherInfo.extend(pack("!I", len(alg)))
+    otherInfo.extend(bytes(alg))
+    otherInfo.extend(pack("!I", len(apu)))
+    otherInfo.extend(str.encode(apu, 'utf8'))
+    otherInfo.extend(pack("!I", len(apv)))
+    otherInfo.extend(str.encode(apv, 'utf8'))
+    otherInfo.extend(pack("!I", dk_len))
     return concat_sha256(Z, dk_len, otherInfo)


### PR DESCRIPTION
Hello IdentityPython-team,

the key derivation for the Elliptic Curve Diffie-Hellman algorithms is not correctly working as intended in the RFC7518 (JWA) chapter 4.6.2. In reference to the National Institute of Standards and Technology publication NIST.SP.800-56Ar2 chapter 5.8.1.2.1., the "OtherInfo" parameter, used in the concat key derivation algorithm, should consist of bytes containing the length for each information to be assembled to the byte array. This length bytes are missing for the "AlgorithmID" information in the "extra.py" file. Please consider this request to fix the key derivation, as otherwise JWEs using Elliptic Curves cannot be processed.

Thanks and best regards,

Vincent Unsel