### PR TITLE
Call logger.debug() instead of logging.debug() (which will go directly to root logger)

### DIFF
--- a/src/jwkest/jwt.py
+++ b/src/jwkest/jwt.py
@@ -82,7 +82,7 @@ class JWT(object):
             else:
                 headers = {'alg': 'none'}
 
-        logging.debug('JWT header: {}'.format(headers))
+        logger.debug('JWT header: {}'.format(headers))
 
         if not parts:
             return ".".join([a.decode() for a in self.b64part])


### PR DESCRIPTION
Logging to logging.debug() will create a root logger handler if none existed, which can result in logging from later application code using the pyjwkest library unintentionally being activated.  Using logger.debug() instead.