### PR TITLE
remove future from install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.5"],
-    install_requires=["pycryptodomex", "requests", "six", "future"],
+    install_requires=["pycryptodomex", "requests", "six"],
     tests_require=['pytest'],
     zip_safe=False,
     scripts=glob.glob('script/*.py'),


### PR DESCRIPTION
https://github.com/IdentityPython/pyjwkest/issues/102

future has a [security vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2025-50817) with no patched version. since it's not doing anything here it would be useful to remove it from install_requires and publish an updated version